### PR TITLE
fix: resolve maintenance report submission error and status update failure

### DIFF
--- a/src/components/MaintenanceList.tsx
+++ b/src/components/MaintenanceList.tsx
@@ -327,6 +327,7 @@ export function MaintenanceList({ currentUser }: MaintenanceListProps) {
                 <option value="all">สถานะ: ทั้งหมด</option>
                 <option value="pending">รอรับเรื่อง</option>
                 <option value="in-progress">กำลังซ่อม</option>
+                <option value="completed">รอตรวจสอบ</option>
                 <option value="resolved">เสร็จสิ้น</option>
               </select>
               <ChevronDown className="w-4 h-4 text-slate-400 absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none" />

--- a/src/components/RoomGrid.tsx
+++ b/src/components/RoomGrid.tsx
@@ -879,7 +879,11 @@ export function RoomGrid({ currentUser, onRoomSelect }: RoomGridProps) {
             setSelectedRoomForMaintenance(null);
           }}
           currentUser={currentUser}
-          onUpdate={loadData}
+          onSuccess={() => {
+            loadData();
+            setShowMaintenanceModal(false);
+            setSelectedRoomForMaintenance(null);
+          }}
         />
       )}
 

--- a/supabase/add_completed_maintenance_status.sql
+++ b/supabase/add_completed_maintenance_status.sql
@@ -1,0 +1,18 @@
+-- Migration: Add 'completed' value to maintenance_status ENUM
+-- Run this in Supabase SQL Editor for existing databases
+-- Issue: https://github.com/AfnanLeewan/resort-management-system/issues/20
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_enum
+        WHERE enumlabel = 'completed'
+          AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'maintenance_status')
+    ) THEN
+        ALTER TYPE maintenance_status ADD VALUE 'completed' AFTER 'in-progress';
+    END IF;
+END;
+$$;
+
+-- Refresh schema cache
+NOTIFY pgrst, 'reload schema';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -20,7 +20,7 @@ CREATE TYPE user_status AS ENUM ('on-duty', 'off-duty', 'on-leave');
 CREATE TYPE booking_status AS ENUM ('reserved', 'checked-in', 'checked-out', 'cancelled');
 CREATE TYPE charge_type AS ENUM ('room', 'early-checkin', 'late-checkout', 'discount', 'other');
 CREATE TYPE maintenance_priority AS ENUM ('low', 'medium', 'high');
-CREATE TYPE maintenance_status AS ENUM ('pending', 'in-progress', 'resolved');
+CREATE TYPE maintenance_status AS ENUM ('pending', 'in-progress', 'completed', 'resolved');
 CREATE TYPE attendance_type AS ENUM ('check-in', 'check-out', 'leave');
 CREATE TYPE transaction_type AS ENUM ('in', 'out');
 

--- a/supabase/uat_setup.sql
+++ b/supabase/uat_setup.sql
@@ -27,7 +27,7 @@ CREATE TYPE user_status AS ENUM ('on-duty', 'off-duty', 'on-leave');
 CREATE TYPE booking_status AS ENUM ('reserved', 'checked-in', 'checked-out', 'cancelled');
 CREATE TYPE charge_type AS ENUM ('room', 'early-checkin', 'late-checkout', 'discount', 'other');
 CREATE TYPE maintenance_priority AS ENUM ('low', 'medium', 'high');
-CREATE TYPE maintenance_status AS ENUM ('pending', 'in-progress', 'resolved');
+CREATE TYPE maintenance_status AS ENUM ('pending', 'in-progress', 'completed', 'resolved');
 CREATE TYPE attendance_type AS ENUM ('check-in', 'check-out', 'leave');
 CREATE TYPE transaction_type AS ENUM ('in', 'out');
 


### PR DESCRIPTION
Fixes #2020

## Changes

- `src/components/RoomGrid.tsx`: Pass `onSuccess` (instead of `onUpdate`) to `MaintenanceReportModal` so the modal closes and data refreshes after successful submission
- `src/components/MaintenanceList.tsx`: Add "รอตรวจสอบ" (completed) option to status filter dropdown
- `supabase/schema.sql` & `supabase/uat_setup.sql`: Add `completed` to `maintenance_status` ENUM for fresh database setups
- `supabase/add_completed_maintenance_status.sql`: Migration script to apply enum change on existing databases

## Root Causes

**Bug 1:** `MaintenanceReportModal` was passed `onUpdate` instead of `onSuccess`. After successful DB save, calling `onSuccess()` (undefined) threw a TypeError caught by the outer catch block — showing a false failure alert even though the record was already saved.

**Bug 2:** The `maintenance_status` database ENUM was missing the `completed` value needed for the 4-step status workflow (pending → in-progress → completed → resolved).

> ⚠️ **Action required:** Run `supabase/add_completed_maintenance_status.sql` in your Supabase SQL Editor to apply the enum migration on the existing database.

Generated with [Claude Code](https://claude.ai/code)