### PR TITLE
fix: resolve maintenance report submission error and status update fa…

### DIFF
--- a/src/components/MaintenanceList.tsx
+++ b/src/components/MaintenanceList.tsx
@@ -327,6 +327,7 @@ export function MaintenanceList({ currentUser }: MaintenanceListProps) {
                 <option value="all">สถานะ: ทั้งหมด</option>
                 <option value="pending">รอรับเรื่อง</option>
                 <option value="in-progress">กำลังซ่อม</option>
+                <option value="completed">รอตรวจสอบ</option>
                 <option value="resolved">เสร็จสิ้น</option>
               </select>
               <ChevronDown className="w-4 h-4 text-slate-400 absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none" />

--- a/src/components/RoomGrid.tsx
+++ b/src/components/RoomGrid.tsx
@@ -879,7 +879,11 @@ export function RoomGrid({ currentUser, onRoomSelect }: RoomGridProps) {
             setSelectedRoomForMaintenance(null);
           }}
           currentUser={currentUser}
-          onUpdate={loadData}
+          onSuccess={() => {
+            loadData();
+            setShowMaintenanceModal(false);
+            setSelectedRoomForMaintenance(null);
+          }}
         />
       )}
 

--- a/supabase/add_completed_maintenance_status.sql
+++ b/supabase/add_completed_maintenance_status.sql
@@ -1,0 +1,18 @@
+-- Migration: Add 'completed' value to maintenance_status ENUM
+-- Run this in Supabase SQL Editor for existing databases
+-- Issue: https://github.com/AfnanLeewan/resort-management-system/issues/20
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_enum
+        WHERE enumlabel = 'completed'
+          AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'maintenance_status')
+    ) THEN
+        ALTER TYPE maintenance_status ADD VALUE 'completed' AFTER 'in-progress';
+    END IF;
+END;
+$$;
+
+-- Refresh schema cache
+NOTIFY pgrst, 'reload schema';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -20,7 +20,7 @@ CREATE TYPE user_status AS ENUM ('on-duty', 'off-duty', 'on-leave');
 CREATE TYPE booking_status AS ENUM ('reserved', 'checked-in', 'checked-out', 'cancelled');
 CREATE TYPE charge_type AS ENUM ('room', 'early-checkin', 'late-checkout', 'discount', 'other');
 CREATE TYPE maintenance_priority AS ENUM ('low', 'medium', 'high');
-CREATE TYPE maintenance_status AS ENUM ('pending', 'in-progress', 'resolved');
+CREATE TYPE maintenance_status AS ENUM ('pending', 'in-progress', 'completed', 'resolved');
 CREATE TYPE attendance_type AS ENUM ('check-in', 'check-out', 'leave');
 CREATE TYPE transaction_type AS ENUM ('in', 'out');
 

--- a/supabase/uat_setup.sql
+++ b/supabase/uat_setup.sql
@@ -27,7 +27,7 @@ CREATE TYPE user_status AS ENUM ('on-duty', 'off-duty', 'on-leave');
 CREATE TYPE booking_status AS ENUM ('reserved', 'checked-in', 'checked-out', 'cancelled');
 CREATE TYPE charge_type AS ENUM ('room', 'early-checkin', 'late-checkout', 'discount', 'other');
 CREATE TYPE maintenance_priority AS ENUM ('low', 'medium', 'high');
-CREATE TYPE maintenance_status AS ENUM ('pending', 'in-progress', 'resolved');
+CREATE TYPE maintenance_status AS ENUM ('pending', 'in-progress', 'completed', 'resolved');
 CREATE TYPE attendance_type AS ENUM ('check-in', 'check-out', 'leave');
 CREATE TYPE transaction_type AS ENUM ('in', 'out');
 


### PR DESCRIPTION
…ilure

Bug 1 (RoomGrid.tsx): MaintenanceReportModal was passed `onUpdate` instead of the expected `onSuccess` prop. On successful submission, calling `onSuccess()` threw TypeError (undefined is not a function), which the catch block caught and showed the false failure alert — even though the record had already been saved to the database.

Bug 2 (schema): The `maintenance_status` ENUM only had 3 values (pending, in-progress, resolved) but the UI workflow uses a 4th step `completed` (รอตรวจสอบ). Updating in-progress → completed was rejected by Supabase with an invalid enum error, blocking all status progression after accepting a job.

Fixes:
- RoomGrid.tsx: pass `onSuccess` with correct close logic to modal
- MaintenanceList.tsx: add `completed` option to status filter dropdown
- supabase/schema.sql + uat_setup.sql: add `completed` to enum for new setups
- supabase/add_completed_maintenance_status.sql: migration for existing DBs